### PR TITLE
chore: add comparison operators and check for operands in Expr

### DIFF
--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -21,19 +21,60 @@ impl LiteralValue {
         }
     }
 
-    pub fn is_falsy(&self) -> bool {
+    pub fn is_truthy(&self) -> bool {
         match self {
-            LiteralValue::NullVal => true,
-            LiteralValue::BooleanVal(b) => !b,
-            LiteralValue::NumberVal(n) => *n == 0,
-            LiteralValue::FloatVal(f) => *f == 0.0,
-            LiteralValue::StringVal(s) => s.is_empty(),
+            LiteralValue::NullVal => false,
+            LiteralValue::BooleanVal(b) => *b,
+            LiteralValue::FloatVal(f) => *f != 0.0,
+            LiteralValue::NumberVal(n) => *n != 0,
+            LiteralValue::StringVal(s) => s.len() > 0,
+            LiteralValue::IdentifierVal(_) => true,
             _ => false
         }
     }
 
+    pub fn is_equal(self_val: LiteralValue, other_val: LiteralValue) -> bool {
+        match self_val {
+            LiteralValue::StringVal(s) => {
+                match other_val {
+                    LiteralValue::StringVal(o) => s == o,
+                    _ => false
+                }
+            },
+            LiteralValue::NumberVal(n) => {
+                match other_val {
+                    LiteralValue::NumberVal(o) => n == o,
+                    _ => false
+                }
+            },
+            LiteralValue::FloatVal(f) => {
+                match other_val {
+                    LiteralValue::FloatVal(o) => f == o,
+                    _ => false
+                }
+            },
+            LiteralValue::NullVal => {
+                match other_val {
+                    LiteralValue::NullVal => true,
+                    _ => false
+                }
+            },
+            LiteralValue::BooleanVal(b) => {
+                match other_val {
+                    LiteralValue::BooleanVal(o) => b == o,
+                    _ => false
+                }
+            },
+            LiteralValue::IdentifierVal(i) => {
+                match other_val {
+                    LiteralValue::IdentifierVal(o) => i == o,
+                    _ => false
+                }
+            },
+            _ => false
+        }
+    }
 }
-
 #[derive(Debug)]
 #[derive(Clone)]
 pub struct Token {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::env::args;
 use std::fs;
 use std::process;
 use crate::lexer::token::Token;
+use crate::parser::expr::Expr;
 use crate::parser::parser::Parser;
 
 fn run_prompt() {
@@ -37,7 +38,7 @@ fn run(contents: String) -> Result<(), String>{
     lexer.scan_tokens();
     let mut parser = Parser::new(lexer.tokens);
     let expr = parser.parse();
-    println!("{}", expr.to_string());
+    expr.interpret();
     Ok(())
 }
 

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1,4 +1,4 @@
-use crate::lexer::token::{LiteralValue, Token};
+use crate::lexer::token::{LiteralValue, Token, TokenType};
 
 pub enum Expr {
     Binary {
@@ -46,6 +46,21 @@ impl Expr {
         }
     }
 
+    pub fn interpret(&self) {
+        match self.evaluate() {
+            Ok(v) => println!("{}", v.to_string()),
+            Err(e) => panic!("{}", e)
+        }
+    }
+
+    pub fn check_operands(left: LiteralValue, right: LiteralValue, message: &str) -> Result<(), String> {
+        match (left, right) {
+            (LiteralValue::NumberVal(_), LiteralValue::NumberVal(_)) => Ok(()),
+            (LiteralValue::FloatVal(_), LiteralValue::FloatVal(_)) => Ok(()),
+            _ => Err(message.to_string())
+        }
+    }
+
     pub fn to_string(&self) -> String {
         match self {
             Expr::Binary { left, operator, right } => format!("({} {} {})", operator.lexeme, left.to_string(), right.to_string()),
@@ -61,7 +76,62 @@ impl Expr {
                 let left = left.evaluate()?;
                 let right = right.evaluate()?;
                 match operator.lexeme.as_str() {
+                    ">" => {
+                        let check_op = Expr::check_operands(left.clone(), right.clone(), "Operands must be two numbers.");
+                        match check_op {
+                            Ok(_) => (),
+                            Err(e) => panic!("{}", e)
+                        }
+                        match (left, right) {
+                            (LiteralValue::NumberVal(l), LiteralValue::NumberVal(r)) => Ok(LiteralValue::BooleanVal(l > r)),
+                            (LiteralValue::FloatVal(l), LiteralValue::FloatVal(r)) => Ok(LiteralValue::BooleanVal(l > r)),
+                            _ => Err("Operands must be two numbers.".to_string())
+                        }
+                    },
+                    "<" => {
+                        let check_op = Expr::check_operands(left.clone(), right.clone(), "Operands must be two numbers.");
+                        match check_op {
+                            Ok(_) => (),
+                            Err(e) => panic!("{}", e)
+                        }
+                        match (left, right) {
+                            (LiteralValue::NumberVal(l), LiteralValue::NumberVal(r)) => Ok(LiteralValue::BooleanVal(l < r)),
+                            (LiteralValue::FloatVal(l), LiteralValue::FloatVal(r)) => Ok(LiteralValue::BooleanVal(l < r)),
+                            _ => Err("Operands must be two numbers.".to_string())
+                        }
+                    },
+                    ">=" => {
+                        let check_op = Expr::check_operands(left.clone(), right.clone(), "Operands must be two numbers.");
+                        match check_op {
+                            Ok(_) => (),
+                            Err(e) => panic!("{}", e)
+                        }
+                        match (left, right) {
+                            (LiteralValue::NumberVal(l), LiteralValue::NumberVal(r)) => Ok(LiteralValue::BooleanVal(l >= r)),
+                            (LiteralValue::FloatVal(l), LiteralValue::FloatVal(r)) => Ok(LiteralValue::BooleanVal(l >= r)),
+                            _ => Err("Operands must be two numbers.".to_string())
+                        }
+                    },
+                    "<=" => {
+                        let check_op = Expr::check_operands(left.clone(), right.clone(), "Operands must be two numbers.");
+                        match check_op {
+                            Ok(_) => (),
+                            Err(e) => panic!("{}", e)
+                        }
+                        match (left, right) {
+                            (LiteralValue::NumberVal(l), LiteralValue::NumberVal(r)) => Ok(LiteralValue::BooleanVal(l <= r)),
+                            (LiteralValue::FloatVal(l), LiteralValue::FloatVal(r)) => Ok(LiteralValue::BooleanVal(l <= r)),
+                            _ => Err("Operands must be two numbers.".to_string())
+                        }
+                    },
+                    "==" => Ok(LiteralValue::BooleanVal(LiteralValue::is_equal(left.clone(), right.clone()))),
+                    "!=" => Ok(LiteralValue::BooleanVal(!LiteralValue::is_equal(left.clone(), right.clone()))),
                     "+" => {
+                        let check_op = Expr::check_operands(left.clone(), right.clone(), "Operands must be two numbers.");
+                        match check_op {
+                            Ok(_) => (),
+                            Err(e) => panic!("{}", e)
+                        }
                         match (left, right) {
                             (LiteralValue::NumberVal(l), LiteralValue::NumberVal(r)) => Ok(LiteralValue::NumberVal(l + r)),
                             (LiteralValue::FloatVal(l), LiteralValue::FloatVal(r)) => Ok(LiteralValue::FloatVal(l + r)),
@@ -70,6 +140,11 @@ impl Expr {
                         }
                     },
                     "-" => {
+                        let check_op = Expr::check_operands(left.clone(), right.clone(), "Operands must be two numbers.");
+                        match check_op {
+                            Ok(_) => (),
+                            Err(e) => panic!("{}", e)
+                        }
                         match (left, right) {
                             (LiteralValue::NumberVal(l), LiteralValue::NumberVal(r)) => Ok(LiteralValue::NumberVal(l - r)),
                             (LiteralValue::FloatVal(l), LiteralValue::FloatVal(r)) => Ok(LiteralValue::FloatVal(l - r)),
@@ -77,6 +152,11 @@ impl Expr {
                         }
                     },
                     "*" => {
+                        let check_op = Expr::check_operands(left.clone(), right.clone(), "Operands must be two numbers.");
+                        match check_op {
+                            Ok(_) => (),
+                            Err(e) => panic!("{}", e)
+                        }
                         match (left, right) {
                             (LiteralValue::NumberVal(l), LiteralValue::NumberVal(r)) => Ok(LiteralValue::NumberVal(l * r)),
                             (LiteralValue::FloatVal(l), LiteralValue::FloatVal(r)) => Ok(LiteralValue::FloatVal(l * r)),
@@ -84,6 +164,11 @@ impl Expr {
                         }
                     },
                     "/" => {
+                        let check_op = Expr::check_operands(left.clone(), right.clone(), "Operands must be two numbers.");
+                        match check_op {
+                            Ok(_) => (),
+                            Err(e) => panic!("{}", e)
+                        }
                         match (left, right) {
                             (LiteralValue::NumberVal(l), LiteralValue::NumberVal(r)) => Ok(LiteralValue::NumberVal(l / r)),
                             (LiteralValue::FloatVal(l), LiteralValue::FloatVal(r)) => Ok(LiteralValue::FloatVal(l / r)),
@@ -100,7 +185,7 @@ impl Expr {
                 match (right, operator.lexeme.as_str()) {
                     (LiteralValue::NumberVal(r), "-") => Ok(LiteralValue::NumberVal(-r)),
                     (LiteralValue::FloatVal(r), "-") => Ok(LiteralValue::FloatVal(-r)),
-                    (any, "!") => any.is_falsy(),
+                    (any, "!") => Ok(LiteralValue::BooleanVal(!any.is_truthy())),
                     _ => Err("Invalid operand.".to_string())
                 }
             }


### PR DESCRIPTION
The changes in this commit add support for comparison operators (> , < , >= , <= , == , !=) in the Expr enum. It also adds a check_operands function to ensure that the operands of these operators are valid numbers. This helps improve the functionality and reliability of the interpreter.