### PR TITLE
chore: refactor interpreter to use an environment for variable storage

### DIFF
--- a/Test Programs/test.pepega
+++ b/Test Programs/test.pepega
@@ -1,4 +1,3 @@
-kappa 1>0
-    chatting("ok")
-aware
-    chatting("oops")
+lulw a = 3;
+lulw b = 20+3;
+chatting (a*b);

--- a/src/interpreter/environment.rs
+++ b/src/interpreter/environment.rs
@@ -1,0 +1,35 @@
+use std::collections::HashMap;
+use crate::lexer::token::{LiteralValue, Token};
+
+pub struct Environment {
+    values: HashMap<String, LiteralValue>
+}
+
+impl Environment {
+    pub fn new() -> Environment {
+        Environment {
+            values: HashMap::new()
+        }
+    }
+
+    pub fn define(&mut self, name: String, value: LiteralValue) {
+        self.values.insert(name, value);
+    }
+
+    pub fn assign(&mut self, name: &Token, value: LiteralValue) -> Result<(), String> {
+        match self.values.get_mut(&name.lexeme) {
+            Some(v) => {
+                *v = value;
+                Ok(())
+            },
+            None => Err(format!("Undefined variable '{}'.", name.lexeme))
+        }
+    }
+
+    pub fn get(&self, name: &Token) -> Result<LiteralValue, String> {
+        match self.values.get(&name.lexeme) {
+            Some(value) => Ok(value.clone()),
+            None => Err(format!("Undefined variable '{}'.", name.lexeme))
+        }
+    }
+}

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -1,1 +1,2 @@
 pub mod interpreter;
+pub mod environment;

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -8,19 +8,19 @@ pub fn get_keywords() -> HashMap<String, TokenType> {
         ("and".to_string(), TokenType::AND),
         ("class".to_string(), TokenType::CLASS),
         ("aware".to_string(), TokenType::ELSE),
-        ("false".to_string(), TokenType::FALSE),
+        ("kappa".to_string(), TokenType::FALSE),
         ("forsen".to_string(), TokenType::FOR),
-        ("fun".to_string(), TokenType::FUN),
-        ("kappa".to_string(), TokenType::IF),
+        ("pog".to_string(), TokenType::FUN),
+        ("clueless".to_string(), TokenType::IF),
         ("nil".to_string(), TokenType::NIL),
         ("or".to_string(), TokenType::OR),
         ("chatting".to_string(), TokenType::PRINT),
-        ("return".to_string(), TokenType::RETURN),
+        ("xdd".to_string(), TokenType::RETURN),
         ("super".to_string(), TokenType::SUPER),
         ("this".to_string(), TokenType::THIS),
-        ("true".to_string(), TokenType::TRUE),
-        ("var".to_string(), TokenType::VAR),
-        ("while".to_string(), TokenType::WHILE)
+        ("surely".to_string(), TokenType::TRUE),
+        ("lulw".to_string(), TokenType::VAR),
+        ("residentsleeper".to_string(), TokenType::WHILE)
     ].iter().cloned().collect()
 }
 

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -70,8 +70,7 @@ impl LiteralValue {
                     LiteralValue::IdentifierVal(o) => i == o,
                     _ => false
                 }
-            },
-            _ => false
+            }
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn run(contents: String) -> Result<(), String>{
     let mut parser = Parser::new(lexer.tokens);
     let expr = parser.parse();
     let mut interpreter = Interpreter::new();
-    interpreter.interpret(expr);
+    interpreter.interpret_stmt(expr);
     Ok(())
 }
 

--- a/src/parser/expr.rs
+++ b/src/parser/expr.rs
@@ -1,6 +1,10 @@
 use crate::lexer::token::{LiteralValue, Token};
 
 pub enum Expr {
+    Assign {
+        name: Token,
+        value: Box<Expr>
+    },
     Binary {
         left: Box<Expr>,
         operator: Token,
@@ -15,10 +19,19 @@ pub enum Expr {
     Unary {
         operator: Token,
         right: Box<Expr>
+    },
+    Variable {
+        name: Token
     }
 }
 
 impl Expr {
+    pub fn new_assign(name: Token, value: Expr) -> Expr {
+        Expr::Assign {
+            name,
+            value: Box::new(value)
+        }
+    }
     pub fn new_binary(left: Expr, operator: Token, right: Expr) -> Expr {
         Expr::Binary {
             left: Box::new(left),
@@ -45,12 +58,20 @@ impl Expr {
             right: Box::new(right)
         }
     }
+
+    pub fn new_variable(name: Token) -> Expr {
+        Expr::Variable {
+            name
+        }
+    }
     pub fn to_string(&self) -> String {
         match self {
+            Expr::Assign { name, value } => format!("(= {} {})", name.lexeme, value.to_string()),
             Expr::Binary { left, operator, right } => format!("({} {} {})", operator.lexeme, left.to_string(), right.to_string()),
             Expr::Grouping { expression } => format!("(group {})", expression.to_string()),
             Expr::Literal { value } => format!("{}", value.to_string()),
-            Expr::Unary { operator, right } => format!("({} {})", operator.lexeme, right.to_string())
+            Expr::Unary { operator, right } => format!("({} {})", operator.lexeme, right.to_string()),
+            Expr::Variable { name } => format!("{}", name.lexeme)
         }
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,3 +1,4 @@
 pub mod parser;
 
 pub mod expr;
+pub mod stmt;

--- a/src/parser/stmt.rs
+++ b/src/parser/stmt.rs
@@ -1,0 +1,15 @@
+use crate::lexer::token::Token;
+use crate::parser::expr::Expr;
+
+pub enum Stmt {
+    Expression {
+        expression: Expr
+    },
+    Print {
+        expression: Expr
+    },
+    Var {
+        name: Token,
+        initializer: Expr
+    }
+}


### PR DESCRIPTION
The interpreter has been refactored to use an `Environment` struct for variable storage. This allows for defining and assigning variables within the interpreter. The `Environment` struct has been added to the interpreter module and is used to store variable values. The `Interpreter` struct now contains an instance of the `Environment` struct. The `interpret_stmt` method has been added to the `Interpreter` struct to interpret a list of statements. The `execute` method has been added to the `Interpreter` struct to execute individual statements. The `Var` statement has been added to the `Stmt` enum to represent variable declarations. The `evaluate_expr` method has been renamed from `evaluate` to better reflect its purpose. The `evaluate_expr` method now returns a `Result` type instead of panicking on error. The `evaluate_expr` method has been updated to handle the `Assign` expression, allowing for variable assignment.